### PR TITLE
Re-reconcile move_to methods in piece.rb

### DIFF
--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -2,11 +2,6 @@ class Piece < ActiveRecord::Base
   
   belongs_to :game
 
-  def move_piece(new_x, new_y)
-    # Add logic to check for validity
-    update_attributes(x_cord: new_x, y_cord: new_y)
-  end
-
 	def is_obstructed?(x, y)
 
 		#check moving direction


### PR DESCRIPTION
Just deleting obsolete move_piece method that snuck its way back in.